### PR TITLE
moves comment to the correct place

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -15,19 +15,20 @@
 
 	<footer id="colophon" class="site-footer">
 
-    <!-- This is just theme info for the demo, so please 
-      remove these and make your own!
+        <!-- This is just theme info for the demo, so please 
+        remove these and make your own!
       
-      Start removing from the next line: -->
+        Start by removing this comment and until the next comment: -->
 
 		<div class="site-info">
 			<a href="<?php echo esc_url( __( 'http://wordpress.org/', 'air' ) ); ?>"><?php printf( esc_html__( 'Proudly powered by %s', 'air' ), 'WordPress' ); ?></a>
 			<span class="theme-info"><?php printf( esc_html__( 'Lightweight like %1$s itself. You are using version %2$s', 'air' ), '<i>air</i>', esc_attr( AIR_VERSION ) ); ?> &mdash; <a href="https://github.com/digitoimistodude/air"><svg width="16" height="16" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1664 896q0 251-146.5 451.5T1139 1625q-27 5-39.5-7t-12.5-30v-211q0-97-52-142 57-6 102.5-18t94-39 81-66.5 53-105T1386 856q0-121-79-206 37-91-8-204-28-9-81 11t-92 44l-38 24q-93-26-192-26t-192 26q-16-11-42.5-27T578 459.5 492 446q-44 113-7 204-79 85-79 206 0 85 20.5 150t52.5 105 80.5 67 94 39 102.5 18q-40 36-49 103-21 10-45 15t-57 5-65.5-21.5T484 1274q-19-32-48.5-52t-49.5-24l-20-3q-21 0-29 4.5t-5 11.5 9 14 13 12l7 5q22 10 43.5 38t31.5 51l10 23q13 38 44 61.5t67 30 69.5 7 55.5-3.5l23-4q0 38 .5 89t.5 54q0 18-13 30t-40 7q-232-77-378.5-277.5T128 896q0-209 103-385.5T510.5 231 896 128t385.5 103T1561 510.5 1664 896z"/></svg> GitHub</a></span>
 		</div><!-- .site-info -->
-	</footer><!-- #colophon -->
 
-  <!-- At least
-    ... Until here. This comment included. -->
+        <!-- At least
+        ... Until here. This comment included. -->
+        
+	</footer><!-- #colophon -->
 
 </div><!-- #page -->
 


### PR DESCRIPTION
There was a possibility to accidentally delete footer end tag. This PR will fix that by moving comment to the correct place in footer. Also, minor styling + grammar fixed.