### PR TITLE
Fix for disappering menu when browser is resized near $responsivenav breakpoint

### DIFF
--- a/sass/extra/_sticky-nav.scss
+++ b/sass/extra/_sticky-nav.scss
@@ -40,7 +40,7 @@ $navheight-collapsed: 54px;
           height: 32px;
         }
 
-        @media(max-width: $responsivenav) {
+        @media(max-width: $responsivenav-1px) {
           margin-top: 0;
         }
       }

--- a/sass/layout/_site-header.scss
+++ b/sass/layout/_site-header.scss
@@ -44,7 +44,7 @@
       }
 
       // The point where navigation turns into mobile nav
-      @media(max-width: $responsivenav) {
+      @media(max-width: $responsivenav-1px) {
         margin-left: 15px;
         margin-top: 10px;
         margin-bottom: 0;

--- a/sass/layout/_site-header.scss
+++ b/sass/layout/_site-header.scss
@@ -22,7 +22,7 @@
     padding-bottom: 0;
     overflow: visible;
 
-    @media(max-width: $responsivenav) {
+    @media(max-width: $responsivenav-1px) {
       padding: 0;
     }
   }

--- a/sass/navigation/_nav-mobile.scss
+++ b/sass/navigation/_nav-mobile.scss
@@ -27,7 +27,7 @@ $hamburger-hover-transition-timing-function: linear;
 }
 
 // Mobile styles
-@media screen and (max-width: $responsivenav) {
+@media screen and (max-width: $responsivenav-1px) {
 
   // Ensure nav stays in the same position when activated
   body {
@@ -230,7 +230,7 @@ $hamburger-hover-transition-timing-function: linear;
     }
   }
 
-  @media (max-width: ($responsivenav)-1px) {
+  @media (max-width: $responsivenav-1px) {
     display: block;
   }
 


### PR DESCRIPTION
Max-width was one pixel too high.