### PR TITLE
Update search.php to use search content template

### DIFF
--- a/search.php
+++ b/search.php
@@ -24,7 +24,7 @@ get_template_part( 'template-parts/hero', get_post_type() ); ?>
 
       <?php while ( have_posts() ) {
       	the_post();
-				get_template_part( 'template-parts/content', get_post_type() );
+				get_template_part( 'template-parts/content', 'search' );
       }
 
       the_posts_navigation();


### PR DESCRIPTION
The search by default uses the default content layout, which echos the whole content for pages.
https://dudetest.xyz/air/?s=wordpress
Maybe the search.php could use the search content layout by default?